### PR TITLE
make the logo a more reasonable size

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-![Flux logo](https://raw.githubusercontent.com/flux-framework/.github/main/images/logo.png)
+<img src="https://raw.githubusercontent.com/flux-framework/.github/main/images/logo.png" alt="Flux logo" width="300" height="200">
 
 ## Organization Administrators
 


### PR DESCRIPTION
The logo takes up my whole screen when I open the framework org, and it'd be nice if it didn't.

<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/f32ecf37-4f79-4aa2-8fff-ec195062ec7d" />
