### PR TITLE
README.md: add Dan as framework administrator

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,6 +6,7 @@
 | ---------------- | ----------------------------------------------------- | ----------- |
 | Jim Garlick      | [garlick](https://github.com/garlick)                 | LLNL        |
 | Mark Grondona    | [grondo](https://github.com/grondo)                   | LLNL        |
+| Daniel Milroy    | [milroy](https://github.com/milroy)                   | LLNL        |
 | Tom Scogland     | [trws](https://github.com/trws)                       | LLNL        |
 
 ## Code of Conduct


### PR DESCRIPTION
Problem: Dan is now a flux-framework administrator/member of steering committe, but is not listed here.

Add him to the README.md.