### PR TITLE
fix the logo size again

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/flux-framework/.github/main/images/logo.png" alt="Flux logo" width="300" height="200">
+<img src="https://raw.githubusercontent.com/flux-framework/.github/main/images/logo.png" alt="Flux logo" height="200">
 
 ## Organization Administrators
 


### PR DESCRIPTION
The logo, for whatever reason, is sized weirdly again and it irritates me. Change: 

<img width="392" height="511" alt="Screenshot 2026-04-22 at 1 38 15 PM" src="https://github.com/user-attachments/assets/c497ae9f-5ffe-4cf8-a0f4-ea1bf5b76151" />


to:

<img width="489" height="521" alt="Screenshot 2026-04-22 at 1 38 59 PM" src="https://github.com/user-attachments/assets/5bc6e112-93c5-4dcc-a6ad-ec0aa51b4f2e" />

by dropping the width requirement and just imposing a height requirement.